### PR TITLE
v0.1.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+## [0.1.0] (2019-03-14)
+
+- Update to Rust 2018 edition ([#4])
+- Use `generic-array` to support generic AES key sizes ([#3])
+
 ## 0.0.1 (2018-08-28)
 
-* Initial release
+- Initial release
+
+[0.1.0]: https://github.com/cryptouri/cryptouri.rs/pull/5
+[#4]: https://github.com/cryptouri/cryptouri.rs/pull/4
+[#3]: https://github.com/cryptouri/cryptouri.rs/pull/3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = """
               URN-like namespace for cryptographic objects (keys, signatures,
               etc) with Bech32 encoding/checksums
               """
-version     = "0.0.1" # Also update html_root_url in lib.rs when bumping this
+version     = "0.1.0" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <bascule@gmail.com>"]
 license     = "MIT OR Apache-2.0"
 homepage    = "https://cryptouri.org"

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 [docs-image]: https://docs.rs/cryptouri/badge.svg
 [docs-link]: https://docs.rs/cryptouri/
 [license-image]: https://img.shields.io/badge/license-MIT/Apache2.0-blue.svg
-[build-image]: https://circleci.com/gh/cryptouri/cryptouri-rs.svg?style=shield
-[build-link]: https://circleci.com/gh/cryptouri/cryptouri-rs
+[build-image]: https://travis-ci.org/cryptouri/cryptouri.rs.svg?branch=master
+[build-link]: https://travis-ci.org/cryptouri/cryptouri.rs
 [gitter-image]: https://badges.gitter.im/badge.svg
 [gitter-link]: https://gitter.im/cryptouri/Lobby
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 #![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://avatars3.githubusercontent.com/u/40766087?u=0267cf8b7fe892bbf35b6114d9eb48adc057d6ff",
-    html_root_url = "https://docs.rs/cryptouri/0.0.1"
+    html_root_url = "https://docs.rs/cryptouri/0.1.0"
 )]
 
 use failure;


### PR DESCRIPTION
- Update to Rust 2018 edition (#4)
- Use `generic-array` to support generic AES key sizes (#3)