### PR TITLE
Remove failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ keywords    = ["bech32", "cryptography", "keys", "security", "uri"]
 travis-ci = { repository = "cryptouri/cryptouri.rs" }
 
 [dependencies]
-failure = "0.1"
 generic-array = "0.13"
 subtle-encoding = { version = "0.4", features = ["bech32-preview"] }
-zeroize = { version = "0.10", features = ["zeroize_derive"] }
+zeroize = { version = "1.0.0-pre", features = ["zeroize_derive"] }

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ A URI-like format for serializing cryptographic objects including keys,
 signatures, and digests using URI generic syntax:
 
 ```
-crypto:public:key:ed25519:6adfsqvzky9t042tlmfujeq88g8wzuhnm2nzxfd0qgdx3ac82ydq3pkr2c
+crypto:pub:key:ed25519:6adfsqvzky9t042tlmfujeq88g8wzuhnm2nzxfd0qgdx3ac82ydqf03cvv
 ```
 
 A URI-safe "dasherized" form is also supported:
 
 ```
-crypto-public-key-ed25519-6adfsqvzky9t042tlmfujeq88g8wzuhnm2nzxfd0qgdx3ac82ydqc3p98e
+crypto-pub-key-ed25519-6adfsqvzky9t042tlmfujeq88g8wzuhnm2nzxfd0qgdx3ac82ydqlu986g
 ```
 
 [Documentation][docs-link]

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -1,6 +1,9 @@
 //! Digest types
 
-use crate::{encoding::Encodable, error::Error};
+use crate::{
+    encoding::Encodable,
+    error::{Error, ErrorKind},
+};
 
 /// NIST SHA-2 family of hash functions
 mod sha2;
@@ -19,7 +22,7 @@ impl Hash {
     pub fn new(alg: &str, bytes: &[u8]) -> Result<Self, Error> {
         let result = match alg {
             SHA256_ALG_ID => Hash::Sha256(Sha256Hash::new(bytes)?),
-            _ => fail!(AlgorithmInvalid, "{}", alg),
+            _ => fail!(ErrorKind::AlgorithmInvalid, "{}", alg),
         };
 
         Ok(result)

--- a/src/hash/sha2.rs
+++ b/src/hash/sha2.rs
@@ -1,6 +1,9 @@
 //! SHA2 hash types
 
-use crate::{algorithm::SHA256_ALG_ID, error::Error};
+use crate::{
+    algorithm::SHA256_ALG_ID,
+    error::{Error, ErrorKind},
+};
 
 /// Size of a SHA-256 hash
 pub const SHA256_HASH_SIZE: usize = 32;
@@ -13,7 +16,7 @@ impl Sha256Hash {
     pub fn new(slice: &[u8]) -> Result<Self, Error> {
         if slice.len() != SHA256_HASH_SIZE {
             fail!(
-                ParseError,
+                ErrorKind::ParseError,
                 "bad SHA-256 hash length: {} (expected {})",
                 slice.len(),
                 SHA256_HASH_SIZE

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ pub use crate::{encoding::Encodable, secret_key::AsSecretSlice};
 
 use crate::{
     encoding::{Encoding, DASHERIZED_ENCODING, URI_ENCODING},
-    error::Error,
+    error::{Error, ErrorKind},
     hash::Hash,
     parts::Parts,
     public_key::PublicKey,
@@ -83,7 +83,11 @@ impl CryptoUri {
                 &parts.data,
             )?)
         } else {
-            fail!(SchemeInvalid, "unknown CryptoURI prefix: {}", parts.prefix)
+            fail!(
+                ErrorKind::SchemeInvalid,
+                "unknown CryptoURI prefix: {}",
+                parts.prefix
+            )
         };
 
         Ok(Self {

--- a/src/public_key.rs
+++ b/src/public_key.rs
@@ -1,6 +1,10 @@
 //! Public key types
 
-use crate::{algorithm::ED25519_ALG_ID, encoding::Encodable, error::Error};
+use crate::{
+    algorithm::ED25519_ALG_ID,
+    encoding::Encodable,
+    error::{Error, ErrorKind},
+};
 
 /// Ed25519 elliptic curve digital signature algorithm (RFC 8032)
 mod ed25519;
@@ -18,7 +22,7 @@ impl PublicKey {
     pub fn new(alg: &str, bytes: &[u8]) -> Result<Self, Error> {
         let result = match alg {
             ED25519_ALG_ID => PublicKey::Ed25519(Ed25519PublicKey::new(bytes)?),
-            _ => fail!(AlgorithmInvalid, "{}", alg),
+            _ => fail!(ErrorKind::AlgorithmInvalid, "{}", alg),
         };
 
         Ok(result)

--- a/src/public_key/ed25519.rs
+++ b/src/public_key/ed25519.rs
@@ -1,6 +1,9 @@
 //! Ed25519 public keys
 
-use crate::{algorithm::ED25519_ALG_ID, error::Error};
+use crate::{
+    algorithm::ED25519_ALG_ID,
+    error::{Error, ErrorKind},
+};
 
 /// Size of an Ed25519 public key
 pub const ED25519_PUBKEY_SIZE: usize = 32;
@@ -13,7 +16,7 @@ impl Ed25519PublicKey {
     pub fn new(slice: &[u8]) -> Result<Self, Error> {
         if slice.len() != ED25519_PUBKEY_SIZE {
             fail!(
-                ParseError,
+                ErrorKind::ParseError,
                 "bad Ed25519 public key length: {} (expected {})",
                 slice.len(),
                 ED25519_PUBKEY_SIZE

--- a/src/secret_key.rs
+++ b/src/secret_key.rs
@@ -3,7 +3,7 @@
 use crate::{
     algorithm::{AES128GCM_ALG_ID, AES256GCM_ALG_ID, ED25519_ALG_ID},
     encoding::Encodable,
-    error::Error,
+    error::{Error, ErrorKind},
 };
 
 /// Advanced Encryption Standard (AES - FIPS 197)
@@ -34,7 +34,7 @@ impl SecretKey {
             AES128GCM_ALG_ID => SecretKey::Aes128Gcm(Aes128GcmKey::from_slice(slice)?),
             AES256GCM_ALG_ID => SecretKey::Aes256Gcm(Aes256GcmKey::from_slice(slice)?),
             ED25519_ALG_ID => SecretKey::Ed25519(Ed25519SecretKey::from_slice(slice)?),
-            _ => fail!(AlgorithmInvalid, "{}", alg),
+            _ => fail!(ErrorKind::AlgorithmInvalid, "{}", alg),
         };
 
         Ok(result)

--- a/src/secret_key/aes.rs
+++ b/src/secret_key/aes.rs
@@ -3,7 +3,7 @@
 use super::AsSecretSlice;
 use crate::{
     algorithm::{AES128GCM_ALG_ID, AES256GCM_ALG_ID},
-    error::Error,
+    error::{Error, ErrorKind},
 };
 use generic_array::{
     typenum::{U16, U32},
@@ -29,7 +29,7 @@ where
     pub fn from_slice(slice: &[u8]) -> Result<Self, Error> {
         if slice.len() != Length::to_usize() {
             fail!(
-                ParseError,
+                ErrorKind::ParseError,
                 "bad AES-{} key length: {} (expected {})",
                 Length::to_usize() * 8,
                 slice.len(),

--- a/src/secret_key/ed25519.rs
+++ b/src/secret_key/ed25519.rs
@@ -1,7 +1,10 @@
 //! The Ed25519 digital signature algorithm
 
 use super::AsSecretSlice;
-use crate::{algorithm::ED25519_ALG_ID, error::Error};
+use crate::{
+    algorithm::ED25519_ALG_ID,
+    error::{Error, ErrorKind},
+};
 use zeroize::Zeroize;
 
 /// Size of an Ed25519 secret key
@@ -23,7 +26,7 @@ impl Ed25519SecretKey {
     pub fn from_slice(slice: &[u8]) -> Result<Self, Error> {
         if slice.len() != ED25519_SECKEY_SIZE {
             fail!(
-                ParseError,
+                ErrorKind::ParseError,
                 "bad Ed25519 secret key length: {} (expected {})",
                 slice.len(),
                 ED25519_SECKEY_SIZE

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -1,6 +1,10 @@
 //! Cryptographic signatures
 
-use crate::{algorithm::ED25519_ALG_ID, encoding::Encodable, error::Error};
+use crate::{
+    algorithm::ED25519_ALG_ID,
+    encoding::Encodable,
+    error::{Error, ErrorKind},
+};
 
 /// Ed25519 elliptic curve digital signature algorithm (RFC 8032)
 mod ed25519;
@@ -18,7 +22,7 @@ impl Signature {
     pub fn new(alg: &str, bytes: &[u8]) -> Result<Self, Error> {
         let result = match alg {
             ED25519_ALG_ID => Signature::Ed25519(Ed25519Signature::new(bytes)?),
-            _ => fail!(AlgorithmInvalid, "{}", alg),
+            _ => fail!(ErrorKind::AlgorithmInvalid, "{}", alg),
         };
 
         Ok(result)

--- a/src/signature/ed25519.rs
+++ b/src/signature/ed25519.rs
@@ -1,6 +1,9 @@
 //! Ed25519 signatures
 
-use crate::{algorithm::ED25519_ALG_ID, error::Error};
+use crate::{
+    algorithm::ED25519_ALG_ID,
+    error::{Error, ErrorKind},
+};
 use zeroize::Zeroize;
 
 /// Size of an Ed25519 signature
@@ -14,7 +17,7 @@ impl Ed25519Signature {
     pub fn new(slice: &[u8]) -> Result<Self, Error> {
         if slice.len() != ED25519_SIGNATURE_SIZE {
             fail!(
-                ParseError,
+                ErrorKind::ParseError,
                 "bad Ed25519 signature length: {} (expected {})",
                 slice.len(),
                 ED25519_SIGNATURE_SIZE


### PR DESCRIPTION
...and replace it with... nothing.

This refactors the error types into more straightforward `std::error::Error`-based ones, now that it has much of the functionality we originally were using `failure` for.