### PR TITLE
v0.2.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+## [0.2.0] (2019-10-07)
+
+- Remove `failure` ([#15])
+- Upgrade `zeroize` to 1.0.0-pre ([#15])
+- Redo toplevel namespace with shorter prefixes ([#14])
+- Upgrade `subtle-encoding` to 0.4 ([#12])
+- Upgrade `generic-array` to 0.13 ([#11])
+
 ## [0.1.1] (2019-06-04)
 
 - Upgrade `zeroize` to v0.9.1 ([#8])
@@ -11,6 +19,11 @@
 
 - Initial release
 
+[0.2.0]: https://github.com/cryptouri/cryptouri.rs/pull/16
+[#15]: https://github.com/cryptouri/cryptouri.rs/pull/15
+[#14]: https://github.com/cryptouri/cryptouri.rs/pull/14
+[#12]: https://github.com/cryptouri/cryptouri.rs/pull/12
+[#11]: https://github.com/cryptouri/cryptouri.rs/pull/11
 [0.1.1]: https://github.com/cryptouri/cryptouri.rs/pull/9
 [#8]: https://github.com/cryptouri/cryptouri.rs/pull/8
 [0.1.0]: https://github.com/cryptouri/cryptouri.rs/pull/5

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name        = "cryptouri"
 description = """
-              URN-like namespace for cryptographic objects (keys, signatures,
-              etc) with Bech32 encoding/checksums
-              """
-version     = "0.1.1" # Also update html_root_url in lib.rs when bumping this
+URN-like namespace for cryptographic objects (keys, signatures,
+etc) with Bech32 encoding/checksums
+"""
+version     = "0.2.0" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <bascule@gmail.com>"]
 license     = "Apache-2.0 OR MIT"
 homepage    = "https://cryptouri.org"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 #![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://avatars3.githubusercontent.com/u/40766087?u=0267cf8b7fe892bbf35b6114d9eb48adc057d6ff",
-    html_root_url = "https://docs.rs/cryptouri/0.1.1"
+    html_root_url = "https://docs.rs/cryptouri/0.2.0"
 )]
 
 #[macro_use]


### PR DESCRIPTION
- Remove `failure` (#15)
- Upgrade `zeroize` to 1.0.0-pre (#15)
- Redo toplevel namespace with shorter prefixes (#14)
- Upgrade `subtle-encoding` to 0.4 (#12)
- Upgrade `generic-array` to 0.13 (#11)