### PR TITLE
Use the `secrecy` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,33 +4,16 @@
 name = "cryptouri"
 version = "0.2.0"
 dependencies = [
- "generic-array 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "secrecy 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle-encoding 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
  "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "proc-macro2"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "quote"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -42,63 +25,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "typenum"
-version = "1.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "zeroize"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "zeroize_derive 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [metadata]
-"checksum generic-array 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0ed1e761351b56f54eb9dcd0cfaca9fd0daecf93918e1cfc01c8a3d26ee7adcd"
-"checksum proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3acb317c6ff86a4e579dfa00fc5e6cca91ecbb4e7eb2df0468805b674eb88548"
-"checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
+"checksum secrecy 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9182278ed645df3477a9c27bfee0621c621aa16f6972635f7f795dae3d81070f"
 "checksum subtle-encoding 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cbc5188a16f729680b6d495b0deaa776944b8e509d24b7f989489b0d8bbcb63b"
-"checksum syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)" = "af6f3550d8dff9ef7dc34d384ac6f107e5d31c8f57d9f28e0081503f547ac8f5"
-"checksum synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
-"checksum typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
-"checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3cbac2ed2ba24cc90f5e06485ac8c7c1e5449fe8911aef4d8877218af021a5b8"
-"checksum zeroize_derive 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de251eec69fc7c1bc3923403d18ececb929380e016afe103da75f396704f8ca2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,5 @@ keywords    = ["bech32", "cryptography", "keys", "security", "uri"]
 travis-ci = { repository = "cryptouri/cryptouri.rs" }
 
 [dependencies]
-generic-array = "0.13"
+secrecy = "0.6"
 subtle-encoding = { version = "0.5", features = ["bech32-preview"] }
-zeroize = { version = "1", features = ["zeroize_derive"] }

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -98,7 +98,38 @@ macro_rules! impl_encodable_public_key {
 
 macro_rules! impl_encodable_secret_key {
     ($name:ident, $alg:expr) => {
-        impl_encodable!(secret_key_scheme, $name, $alg);
+        impl crate::encoding::Encodable for $name {
+            #[inline]
+            fn to_uri_string(&self) -> String {
+                use secrecy::ExposeSecret;
+                use subtle_encoding::bech32::{self, Bech32};
+                Bech32::new(
+                    bech32::DEFAULT_CHARSET,
+                    $crate::encoding::URI_ENCODING.delimiter,
+                )
+                .encode(
+                    $crate::encoding::URI_ENCODING.secret_key_scheme.to_owned() + $alg,
+                    &self.expose_secret()[..],
+                )
+            }
+
+            #[inline]
+            fn to_dasherized_string(&self) -> String {
+                use secrecy::ExposeSecret;
+                use subtle_encoding::bech32::{self, Bech32};
+                Bech32::new(
+                    bech32::DEFAULT_CHARSET,
+                    $crate::encoding::DASHERIZED_ENCODING.delimiter,
+                )
+                .encode(
+                    $crate::encoding::DASHERIZED_ENCODING
+                        .secret_key_scheme
+                        .to_owned()
+                        + $alg,
+                    &self.expose_secret()[..],
+                )
+            }
+        }
     };
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -88,19 +88,19 @@ impl Display for ErrorKind {
 impl std::error::Error for ErrorKind {}
 
 /// Create a new error (of a given enum variant) with a formatted message
-macro_rules! err {
+macro_rules! format_err {
     ($kind:path, $msg:expr) => {
         crate::error::Error::new($kind, Some($msg.to_string()))
     };
     ($kind:path, $fmt:expr, $($arg:tt)+) => {
-        err!($kind, format!($fmt, $($arg)+))
+        format_err!($kind, format!($fmt, $($arg)+))
     };
 }
 
 /// Create and return an error with a formatted message
 macro_rules! fail {
     ($kind:path, $msg:expr) => {
-        return Err(err!($kind, $msg).into());
+        return Err(format_err!($kind, $msg).into());
     };
     ($kind:path, $fmt:expr, $($arg:tt)+) => {
         fail!($kind, format!($fmt, $($arg)+));

--- a/src/secret_key/aes.rs
+++ b/src/secret_key/aes.rs
@@ -1,68 +1,76 @@
 //! Advanced Encryption Standard (AES) keys
 
-use super::AsSecretSlice;
+// TODO(tarcieri): use a macro, generic-array, or const generics to DRY out 128 vs 256
+
 use crate::{
     algorithm::{AES128GCM_ALG_ID, AES256GCM_ALG_ID},
     error::{Error, ErrorKind},
 };
-use generic_array::{
-    typenum::{U16, U32},
-    ArrayLength, GenericArray,
-};
-use zeroize::Zeroize;
+use secrecy::{DebugSecret, ExposeSecret, Secret};
+use std::convert::{TryFrom, TryInto};
 
-pub struct AesGcmKey<Length>(GenericArray<u8, Length>)
-where
-    Length: ArrayLength<u8>;
+/// Size of an AES-128 key in bytes
+pub const AES128_KEY_SIZE: usize = 16;
 
-impl<Length> AesGcmKey<Length>
-where
-    Length: ArrayLength<u8>,
-{
-    /// Create a new AES-GCM key from the given byte array
-    pub fn new(bytes: GenericArray<u8, Length>) -> Self {
-        AesGcmKey(bytes)
-    }
-
-    /// Create a new AES-GCM key from the given slice, returning an error
-    /// if it's the wrong length
-    pub fn from_slice(slice: &[u8]) -> Result<Self, Error> {
-        if slice.len() != Length::to_usize() {
-            fail!(
-                ErrorKind::ParseError,
-                "bad AES-{} key length: {} (expected {})",
-                Length::to_usize() * 8,
-                slice.len(),
-                Length::to_usize()
-            );
-        }
-
-        Ok(AesGcmKey::new(GenericArray::clone_from_slice(slice)))
-    }
-}
-
-impl<Length> AsSecretSlice for AesGcmKey<Length>
-where
-    Length: ArrayLength<u8>,
-{
-    fn as_secret_slice(&self) -> &[u8] {
-        self.0.as_ref()
-    }
-}
-
-impl<Length> Drop for AesGcmKey<Length>
-where
-    Length: ArrayLength<u8>,
-{
-    fn drop(&mut self) {
-        self.0.as_mut().zeroize()
-    }
-}
+/// Size of an AES-256 key in bytes
+pub const AES256_KEY_SIZE: usize = 32;
 
 /// AES-128 in Galois/Counter Mode (GCM)
-pub type Aes128GcmKey = AesGcmKey<U16>;
-impl_encodable_secret_key!(Aes128GcmKey, AES128GCM_ALG_ID);
+#[derive(Clone)]
+pub struct Aes128GcmKey(Secret<[u8; AES128_KEY_SIZE]>);
 
 /// AES-256 in Galois/Counter Mode (GCM)
-pub type Aes256GcmKey = AesGcmKey<U32>;
+#[derive(Clone)]
+pub struct Aes256GcmKey(Secret<[u8; AES256_KEY_SIZE]>);
+
+impl TryFrom<&[u8]> for Aes128GcmKey {
+    type Error = Error;
+
+    fn try_from(slice: &[u8]) -> Result<Self, Error> {
+        slice
+            .try_into()
+            .map(|bytes| Aes128GcmKey(Secret::new(bytes)))
+            .map_err(|_| {
+                format_err!(
+                    ErrorKind::ParseError,
+                    "bad AES-128 key length: {} (expected 16-bytes)",
+                    slice.len(),
+                )
+            })
+    }
+}
+
+impl TryFrom<&[u8]> for Aes256GcmKey {
+    type Error = Error;
+
+    fn try_from(slice: &[u8]) -> Result<Self, Error> {
+        slice
+            .try_into()
+            .map(|bytes| Aes256GcmKey(Secret::new(bytes)))
+            .map_err(|_| {
+                format_err!(
+                    ErrorKind::ParseError,
+                    "bad AES-256 key length: {} (expected 32-bytes)",
+                    slice.len(),
+                )
+            })
+    }
+}
+
+impl DebugSecret for Aes128GcmKey {}
+impl DebugSecret for Aes256GcmKey {}
+
+impl ExposeSecret<[u8; AES128_KEY_SIZE]> for Aes128GcmKey {
+    fn expose_secret(&self) -> &[u8; AES128_KEY_SIZE] {
+        self.0.expose_secret()
+    }
+}
+
+impl ExposeSecret<[u8; AES256_KEY_SIZE]> for Aes256GcmKey {
+    fn expose_secret(&self) -> &[u8; AES256_KEY_SIZE] {
+        self.0.expose_secret()
+    }
+}
+
+impl_encodable_secret_key!(Aes128GcmKey, AES128GCM_ALG_ID);
 impl_encodable_secret_key!(Aes256GcmKey, AES256GCM_ALG_ID);

--- a/src/secret_key/ed25519.rs
+++ b/src/secret_key/ed25519.rs
@@ -1,48 +1,40 @@
 //! The Ed25519 digital signature algorithm
 
-use super::AsSecretSlice;
 use crate::{
     algorithm::ED25519_ALG_ID,
     error::{Error, ErrorKind},
 };
-use zeroize::Zeroize;
+use secrecy::{DebugSecret, ExposeSecret, Secret};
+use std::convert::{TryFrom, TryInto};
 
 /// Size of an Ed25519 secret key
-pub const ED25519_SECKEY_SIZE: usize = 32;
+pub const ED25519_SEC_KEY_SIZE: usize = 32;
 
 /// Ed25519 secret key (i.e. compressed Edwards-y coordinate)
-#[derive(Zeroize)]
-#[zeroize(drop)]
-pub struct Ed25519SecretKey([u8; ED25519_SECKEY_SIZE]);
+pub struct Ed25519SecretKey(Secret<[u8; ED25519_SEC_KEY_SIZE]>);
 
-impl Ed25519SecretKey {
-    /// Create a new Ed25519SecretKey object from the given byte array
-    /// (containing a randomly chosen secret scalar
-    pub fn new(bytes: [u8; ED25519_SECKEY_SIZE]) -> Self {
-        Ed25519SecretKey(bytes)
-    }
+impl TryFrom<&[u8]> for Ed25519SecretKey {
+    type Error = Error;
 
-    /// Create a new Ed25519 secret key from a byte slice
-    pub fn from_slice(slice: &[u8]) -> Result<Self, Error> {
-        if slice.len() != ED25519_SECKEY_SIZE {
-            fail!(
-                ErrorKind::ParseError,
-                "bad Ed25519 secret key length: {} (expected {})",
-                slice.len(),
-                ED25519_SECKEY_SIZE
-            );
-        }
-
-        let mut bytes = [0u8; ED25519_SECKEY_SIZE];
-        bytes.copy_from_slice(slice);
-
-        Ok(Self::new(bytes))
+    fn try_from(slice: &[u8]) -> Result<Self, Error> {
+        slice
+            .try_into()
+            .map(|bytes| Ed25519SecretKey(Secret::new(bytes)))
+            .map_err(|_| {
+                format_err!(
+                    ErrorKind::ParseError,
+                    "bad Ed25519 secret key length: {} (expected 32-bytes)",
+                    slice.len(),
+                )
+            })
     }
 }
 
-impl AsSecretSlice for Ed25519SecretKey {
-    fn as_secret_slice(&self) -> &[u8] {
-        self.0.as_ref()
+impl DebugSecret for Ed25519SecretKey {}
+
+impl ExposeSecret<[u8; ED25519_SEC_KEY_SIZE]> for Ed25519SecretKey {
+    fn expose_secret(&self) -> &[u8; ED25519_SEC_KEY_SIZE] {
+        self.0.expose_secret()
     }
 }
 

--- a/src/signature/ed25519.rs
+++ b/src/signature/ed25519.rs
@@ -4,7 +4,6 @@ use crate::{
     algorithm::ED25519_ALG_ID,
     error::{Error, ErrorKind},
 };
-use zeroize::Zeroize;
 
 /// Size of an Ed25519 signature
 pub const ED25519_SIGNATURE_SIZE: usize = 64;
@@ -34,13 +33,6 @@ impl Ed25519Signature {
 impl AsRef<[u8]> for Ed25519Signature {
     fn as_ref(&self) -> &[u8] {
         &self.0[..]
-    }
-}
-
-// Signatures may be sensitive. Can't hurt (I hope!)
-impl Drop for Ed25519Signature {
-    fn drop(&mut self) {
-        (&mut self.0[..]).zeroize()
     }
 }
 

--- a/tests/secret_key_test.rs
+++ b/tests/secret_key_test.rs
@@ -2,13 +2,15 @@ macro_rules! secret_key_test {
     ($name:ident, $keytype:ident, $uri:expr, $dasherized:expr, $bytes:expr) => {
         mod $name {
             use cryptouri::secret_key::$keytype;
-            use cryptouri::{AsSecretSlice, CryptoUri, Encodable};
+            use cryptouri::{CryptoUri, Encodable};
+            use secrecy::ExposeSecret;
+            use std::convert::TryFrom;
 
             #[test]
             fn parse_uri() {
                 let key = CryptoUri::parse_uri($uri).unwrap();
                 assert_eq!(
-                    key.secret_key().unwrap().$name().unwrap().as_secret_slice(),
+                    key.secret_key().unwrap().$name().unwrap().expose_secret(),
                     $bytes
                 );
             }
@@ -17,20 +19,20 @@ macro_rules! secret_key_test {
             fn parse_dasherized() {
                 let key = CryptoUri::parse_dasherized($dasherized).unwrap();
                 assert_eq!(
-                    key.secret_key().unwrap().$name().unwrap().as_secret_slice(),
+                    key.secret_key().unwrap().$name().unwrap().expose_secret(),
                     $bytes
                 );
             }
 
             #[test]
             fn serialize_uri() {
-                let key = $keytype::from_slice($bytes).unwrap();
+                let key = $keytype::try_from($bytes.as_ref()).unwrap();
                 assert_eq!(&key.to_uri_string(), $uri);
             }
 
             #[test]
             fn serialize_dasherized() {
-                let key = $keytype::from_slice($bytes).unwrap();
+                let key = $keytype::try_from($bytes.as_ref()).unwrap();
                 assert_eq!(&key.to_dasherized_string(), $dasherized);
             }
         }


### PR DESCRIPTION
This crate contained some internal types/traits which provide the same functionality as the `secrecy` crate.

This commit removes those types/traits and switches to the equivalent `secrecy` types/traits, most notably the `secrecy::Secret` wrapper type (which ensures zeroization on drop) and the `ExposeSecret` for accessing the inner secret value.

With this change, this crate no longer needs to depend directly on `zeroize`, but uses it vicariously through `secrecy`.