### PR TITLE
Replace object `::new` methods with  `TryFrom<&[u8]>`

### DIFF
--- a/src/hash.rs
+++ b/src/hash.rs
@@ -11,6 +11,7 @@ use crate::{
     error::{Error, ErrorKind},
 };
 use anomaly::fail;
+use std::convert::TryInto;
 
 /// Digest (i.e. hash) algorithms
 pub enum Hash {
@@ -22,7 +23,7 @@ impl Hash {
     /// Create a new `Digest` for the given algorithm
     pub fn new(alg: &str, bytes: &[u8]) -> Result<Self, Error> {
         let result = match alg {
-            SHA256_ALG_ID => Hash::Sha256(Sha256Hash::new(bytes)?),
+            SHA256_ALG_ID => Hash::Sha256(bytes.try_into()?),
             _ => fail!(ErrorKind::AlgorithmInvalid, "{}", alg),
         };
 

--- a/src/hash/sha2.rs
+++ b/src/hash/sha2.rs
@@ -4,7 +4,8 @@ use crate::{
     algorithm::SHA256_ALG_ID,
     error::{Error, ErrorKind},
 };
-use anomaly::fail;
+use anomaly::format_err;
+use std::convert::{TryFrom, TryInto};
 
 /// Size of a SHA-256 hash
 pub const SHA256_HASH_SIZE: usize = 32;
@@ -12,22 +13,19 @@ pub const SHA256_HASH_SIZE: usize = 32;
 /// NIST SHA-256 hashes
 pub struct Sha256Hash(pub [u8; SHA256_HASH_SIZE]);
 
-impl Sha256Hash {
-    /// Create a new SHA-256 hash
-    pub fn new(slice: &[u8]) -> Result<Self, Error> {
-        if slice.len() != SHA256_HASH_SIZE {
-            fail!(
+impl TryFrom<&[u8]> for Sha256Hash {
+    type Error = Error;
+
+    fn try_from(slice: &[u8]) -> Result<Self, Error> {
+        slice.try_into().map(Sha256Hash).map_err(|_| {
+            format_err!(
                 ErrorKind::ParseError,
                 "bad SHA-256 hash length: {} (expected {})",
                 slice.len(),
                 SHA256_HASH_SIZE
-            );
-        }
-
-        let mut hash_bytes = [0u8; SHA256_HASH_SIZE];
-        hash_bytes.copy_from_slice(slice);
-
-        Ok(Sha256Hash(hash_bytes))
+            )
+            .into()
+        })
     }
 }
 

--- a/src/public_key.rs
+++ b/src/public_key.rs
@@ -6,6 +6,7 @@ use crate::{
     error::{Error, ErrorKind},
 };
 use anomaly::fail;
+use std::convert::TryInto;
 
 /// Ed25519 elliptic curve digital signature algorithm (RFC 8032)
 mod ed25519;
@@ -22,7 +23,7 @@ impl PublicKey {
     /// Create a new `PublicKey` for the given algorithm
     pub fn new(alg: &str, bytes: &[u8]) -> Result<Self, Error> {
         let result = match alg {
-            ED25519_ALG_ID => PublicKey::Ed25519(Ed25519PublicKey::new(bytes)?),
+            ED25519_ALG_ID => PublicKey::Ed25519(bytes.try_into()?),
             _ => fail!(ErrorKind::AlgorithmInvalid, "{}", alg),
         };
 

--- a/src/public_key/ed25519.rs
+++ b/src/public_key/ed25519.rs
@@ -4,7 +4,8 @@ use crate::{
     algorithm::ED25519_ALG_ID,
     error::{Error, ErrorKind},
 };
-use anomaly::fail;
+use anomaly::format_err;
+use std::convert::{TryFrom, TryInto};
 
 /// Size of an Ed25519 public key
 pub const ED25519_PUBKEY_SIZE: usize = 32;
@@ -12,22 +13,19 @@ pub const ED25519_PUBKEY_SIZE: usize = 32;
 /// Ed25519 public key (i.e. compressed Edwards-y coordinate)
 pub struct Ed25519PublicKey(pub [u8; ED25519_PUBKEY_SIZE]);
 
-impl Ed25519PublicKey {
-    /// Create a new Ed25519 public key
-    pub fn new(slice: &[u8]) -> Result<Self, Error> {
-        if slice.len() != ED25519_PUBKEY_SIZE {
-            fail!(
+impl TryFrom<&[u8]> for Ed25519PublicKey {
+    type Error = Error;
+
+    fn try_from(slice: &[u8]) -> Result<Self, Error> {
+        slice.try_into().map(Ed25519PublicKey).map_err(|_| {
+            format_err!(
                 ErrorKind::ParseError,
                 "bad Ed25519 public key length: {} (expected {})",
                 slice.len(),
                 ED25519_PUBKEY_SIZE
-            );
-        }
-
-        let mut key_bytes = [0u8; ED25519_PUBKEY_SIZE];
-        key_bytes.copy_from_slice(slice);
-
-        Ok(Ed25519PublicKey(key_bytes))
+            )
+            .into()
+        })
     }
 }
 

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -11,6 +11,7 @@ use crate::{
     error::{Error, ErrorKind},
 };
 use anomaly::fail;
+use std::convert::TryInto;
 
 /// Signature algorithms
 pub enum Signature {
@@ -22,7 +23,7 @@ impl Signature {
     /// Create a new `Signature` for the given algorithm
     pub fn new(alg: &str, bytes: &[u8]) -> Result<Self, Error> {
         let result = match alg {
-            ED25519_ALG_ID => Signature::Ed25519(Ed25519Signature::new(bytes)?),
+            ED25519_ALG_ID => Signature::Ed25519(bytes.try_into()?),
             _ => fail!(ErrorKind::AlgorithmInvalid, "{}", alg),
         };
 

--- a/src/signature/ed25519.rs
+++ b/src/signature/ed25519.rs
@@ -5,6 +5,7 @@ use crate::{
     error::{Error, ErrorKind},
 };
 use anomaly::fail;
+use core::convert::TryFrom;
 
 /// Size of an Ed25519 signature
 pub const ED25519_SIGNATURE_SIZE: usize = 64;
@@ -12,9 +13,12 @@ pub const ED25519_SIGNATURE_SIZE: usize = 64;
 /// Ed25519 signature (i.e. compressed Edwards-y coordinate)
 pub struct Ed25519Signature(pub [u8; ED25519_SIGNATURE_SIZE]);
 
-impl Ed25519Signature {
-    /// Create a new Ed25519 signature
-    pub fn new(slice: &[u8]) -> Result<Self, Error> {
+impl TryFrom<&[u8]> for Ed25519Signature {
+    type Error = Error;
+
+    fn try_from(slice: &[u8]) -> Result<Self, Error> {
+        // NOTE: Can't use `TryInto` here because `[u8; 64]` doesn't impl
+        // `TryFrom<&[u8]>`
         if slice.len() != ED25519_SIGNATURE_SIZE {
             fail!(
                 ErrorKind::ParseError,

--- a/tests/public_key_test.rs
+++ b/tests/public_key_test.rs
@@ -5,6 +5,7 @@
 mod ed25519 {
     use cryptouri::public_key::Ed25519PublicKey;
     use cryptouri::{CryptoUri, Encodable};
+    use std::convert::TryInto;
 
     const EXAMPLE_URI: &str =
         "crypto:pub:key:ed25519:6adfsqvzky9t042tlmfujeq88g8wzuhnm2nzxfd0qgdx3ac82ydqf03cvv";
@@ -37,13 +38,13 @@ mod ed25519 {
 
     #[test]
     fn serialize_uri() {
-        let key = Ed25519PublicKey::new(EXAMPLE_BYTES).unwrap();
+        let key: Ed25519PublicKey = EXAMPLE_BYTES.try_into().unwrap();
         assert_eq!(&key.to_uri_string(), EXAMPLE_URI);
     }
 
     #[test]
     fn serialize_dasherized() {
-        let key = Ed25519PublicKey::new(EXAMPLE_BYTES).unwrap();
+        let key: Ed25519PublicKey = EXAMPLE_BYTES.try_into().unwrap();
         assert_eq!(&key.to_dasherized_string(), EXAMPLE_DASHERIZED);
     }
 }


### PR DESCRIPTION
Consistently uses `TryFrom<&[u8]>` as the method for instantiating the various cryptographic objects represented by CryptoURIs.