### PR TITLE
Use macro to define AES-GCM key types

### DIFF
--- a/src/secret_key/aes.rs
+++ b/src/secret_key/aes.rs
@@ -24,56 +24,44 @@ pub struct Aes128GcmKey(Secret<[u8; AES128_KEY_SIZE]>);
 #[derive(Clone)]
 pub struct Aes256GcmKey(Secret<[u8; AES256_KEY_SIZE]>);
 
-impl TryFrom<&[u8]> for Aes128GcmKey {
-    type Error = Error;
+macro_rules! impl_aes_gcm_key {
+    ($name:ident, $key_size:expr, $desc:expr) => {
+        impl TryFrom<&[u8]> for $name {
+            type Error = Error;
 
-    fn try_from(slice: &[u8]) -> Result<Self, Error> {
-        slice
-            .try_into()
-            .map(|bytes| Aes128GcmKey(Secret::new(bytes)))
-            .map_err(|_| {
-                format_err!(
-                    ErrorKind::ParseError,
-                    "bad AES-128 key length: {} (expected 16-bytes)",
-                    slice.len(),
-                )
-                .into()
-            })
-    }
+            fn try_from(slice: &[u8]) -> Result<Self, Error> {
+                slice
+                    .try_into()
+                    .map(|bytes| $name(Secret::new(bytes)))
+                    .map_err(|_| {
+                        format_err!(
+                            ErrorKind::ParseError,
+                            concat!(
+                                "bad ",
+                                $desc,
+                                "key length: {} (expected ",
+                                $key_size,
+                                "-bytes)"
+                            ),
+                            slice.len(),
+                        )
+                        .into()
+                    })
+            }
+        }
+
+        impl DebugSecret for $name {}
+
+        impl ExposeSecret<[u8; $key_size]> for $name {
+            fn expose_secret(&self) -> &[u8; $key_size] {
+                self.0.expose_secret()
+            }
+        }
+    };
 }
 
-impl TryFrom<&[u8]> for Aes256GcmKey {
-    type Error = Error;
-
-    fn try_from(slice: &[u8]) -> Result<Self, Error> {
-        slice
-            .try_into()
-            .map(|bytes| Aes256GcmKey(Secret::new(bytes)))
-            .map_err(|_| {
-                format_err!(
-                    ErrorKind::ParseError,
-                    "bad AES-256 key length: {} (expected 32-bytes)",
-                    slice.len(),
-                )
-                .into()
-            })
-    }
-}
-
-impl DebugSecret for Aes128GcmKey {}
-impl DebugSecret for Aes256GcmKey {}
-
-impl ExposeSecret<[u8; AES128_KEY_SIZE]> for Aes128GcmKey {
-    fn expose_secret(&self) -> &[u8; AES128_KEY_SIZE] {
-        self.0.expose_secret()
-    }
-}
-
-impl ExposeSecret<[u8; AES256_KEY_SIZE]> for Aes256GcmKey {
-    fn expose_secret(&self) -> &[u8; AES256_KEY_SIZE] {
-        self.0.expose_secret()
-    }
-}
+impl_aes_gcm_key!(Aes128GcmKey, 16, "AES-128-GCM");
+impl_aes_gcm_key!(Aes256GcmKey, 32, "AES-128-GCM");
 
 impl_encodable_secret_key!(Aes128GcmKey, AES128GCM_ALG_ID);
 impl_encodable_secret_key!(Aes256GcmKey, AES256GCM_ALG_ID);


### PR DESCRIPTION
DRYs out the Aes128GcmKey/Aes256GcmKey types using a macro.

In the future this could hopefully be replaced with const generics.