### PR TITLE
v0.3.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,13 @@
+## [0.3.0] (2020-01-29)
+
+- ChaCha20Poly1305 support ([#26], [#27])
+- Replace object `::new` methods with `TryFrom<&[u8]>` ([#24])
+- Use `anomaly` and `thiserror` for error handling ([#23])
+- Use the `secrecy` crate ([#22])
+- Update `zeroize` requirement from 1.0.0-pre to 1.0 ([#21])
+- Re-export types at toplevel ([#18])
+- Update subtle-encoding requirement from 0.4 to 0.5 ([#17])
+
 ## [0.2.0] (2019-10-07)
 
 - Remove `failure` ([#15])
@@ -19,6 +29,15 @@
 
 - Initial release
 
+[0.3.0]: https://github.com/cryptouri/cryptouri.rs/pull/28
+[#27]: https://github.com/cryptouri/cryptouri.rs/pull/27
+[#26]: https://github.com/cryptouri/cryptouri.rs/pull/26
+[#24]: https://github.com/cryptouri/cryptouri.rs/pull/24
+[#23]: https://github.com/cryptouri/cryptouri.rs/pull/23
+[#22]: https://github.com/cryptouri/cryptouri.rs/pull/22
+[#21]: https://github.com/cryptouri/cryptouri.rs/pull/21
+[#18]: https://github.com/cryptouri/cryptouri.rs/pull/18
+[#17]: https://github.com/cryptouri/cryptouri.rs/pull/17
 [0.2.0]: https://github.com/cryptouri/cryptouri.rs/pull/16
 [#15]: https://github.com/cryptouri/cryptouri.rs/pull/15
 [#14]: https://github.com/cryptouri/cryptouri.rs/pull/14

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cryptouri"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anomaly 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "secrecy 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,10 +4,10 @@ description = """
 URN-like namespace for cryptographic objects (keys, signatures,
 etc) with Bech32 encoding/checksums
 """
-version     = "0.2.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.3.0" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <bascule@gmail.com>"]
 license     = "Apache-2.0 OR MIT"
-homepage    = "https://cryptouri.org"
+homepage    = "https://github.com/cryptouri"
 repository  = "https://github.com/cryptouri/cryptouri.rs/"
 readme      = "README.md"
 edition     = "2018"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 
 #![doc(
     html_logo_url = "https://avatars3.githubusercontent.com/u/40766087?u=0267cf8b7fe892bbf35b6114d9eb48adc057d6ff",
-    html_root_url = "https://docs.rs/cryptouri/0.2.0"
+    html_root_url = "https://docs.rs/cryptouri/0.3.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
- ChaCha20Poly1305 support (#26, #27)
- Replace object `::new` methods with `TryFrom<&[u8]>` (#24)
- Use `anomaly` and `thiserror` for error handling (#23)
- Use the `secrecy` crate (#22)
- Update `zeroize` requirement from 1.0.0-pre to 1.0 (#21)
- Re-export types at toplevel (#18)
- Update subtle-encoding requirement from 0.4 to 0.5 (#17)