### PR TITLE
v0.4.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## [0.4.0] (2020-02-08)
+
+- Add Clone and Debug impls on key/encoding types ([#32])
+- Initial `hkdfsha256` (and alg combination) support ([#30], [#31])
+
 ## [0.3.0] (2020-01-29)
 
 - ChaCha20Poly1305 support ([#26], [#27])
@@ -29,6 +34,10 @@
 
 - Initial release
 
+[0.4.0]: https://github.com/cryptouri/cryptouri.rs/pull/33
+[#32]: https://github.com/cryptouri/cryptouri.rs/pull/32
+[#31]: https://github.com/cryptouri/cryptouri.rs/pull/31
+[#30]: https://github.com/cryptouri/cryptouri.rs/pull/30
 [0.3.0]: https://github.com/cryptouri/cryptouri.rs/pull/28
 [#27]: https://github.com/cryptouri/cryptouri.rs/pull/27
 [#26]: https://github.com/cryptouri/cryptouri.rs/pull/26

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cryptouri"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anomaly 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "secrecy 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 URN-like namespace for cryptographic objects (keys, signatures,
 etc) with Bech32 encoding/checksums
 """
-version     = "0.3.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.4.0" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <bascule@gmail.com>"]
 license     = "Apache-2.0 OR MIT"
 homepage    = "https://github.com/cryptouri"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 
 #![doc(
     html_logo_url = "https://avatars3.githubusercontent.com/u/40766087?u=0267cf8b7fe892bbf35b6114d9eb48adc057d6ff",
-    html_root_url = "https://docs.rs/cryptouri/0.3.0"
+    html_root_url = "https://docs.rs/cryptouri/0.4.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
- Add `Clone` and `Debug` impls on key/encoding types (#32)
- Initial `hkdfsha256` (and alg combination) support (#30, #31)