### PR TITLE
Revamp errors; remove `anomaly` and `displaydoc` deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,98 +3,12 @@
 version = 3
 
 [[package]]
-name = "anomaly"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "550632e31568ae1a5f47998c3aa48563030fc49b9ec91913ca337cf64fbc5ccb"
-dependencies = [
- "backtrace",
-]
-
-[[package]]
-name = "backtrace"
-version = "0.3.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad235dabf00f36301792cfe82499880ba54c6486be094d1047b02bacb67c14e8"
-dependencies = [
- "backtrace-sys",
- "cfg-if",
- "libc",
- "rustc-demangle",
-]
-
-[[package]]
-name = "backtrace-sys"
-version = "0.1.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17b52e737c40a7d75abca20b29a19a0eb7ba9fc72c5a72dd282a0a3c2c0dc35"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "cc"
-version = "1.0.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
-
-[[package]]
-name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-
-[[package]]
 name = "cryptouri"
 version = "0.5.0-pre"
 dependencies = [
- "anomaly",
- "displaydoc",
  "secrecy",
  "subtle-encoding",
 ]
-
-[[package]]
-name = "displaydoc"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc2ab4d5a16117f9029e9a6b5e4e79f4c67f6519bc134210d4d4a04ba31f41b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "libc"
-version = "0.2.67"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb147597cdf94ed43ab7a9038716637d2d1bf2bc571da995d0028dec06bd3018"
-
-[[package]]
-name = "proc-macro2"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c09721c6781493a2a492a96b5a5bf19b65917fe6728884e7c44dd0c60ca3435"
-dependencies = [
- "unicode-xid",
-]
-
-[[package]]
-name = "quote"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
-dependencies = [
- "proc-macro2",
-]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 
 [[package]]
 name = "secrecy"
@@ -113,23 +27,6 @@ checksum = "7dcb1ed7b8330c5eed5441052651dd7a12c75e2ed88f2ec024ae1fa3a5e59945"
 dependencies = [
  "zeroize",
 ]
-
-[[package]]
-name = "syn"
-version = "1.0.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "123bd9499cfb380418d509322d7a6d52e5315f064fe4b3ad18a53d6b92c07859"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-xid",
-]
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,5 @@ rust-version = "1.56"
 travis-ci = { repository = "cryptouri/cryptouri.rs" }
 
 [dependencies]
-anomaly = "0.2"
-displaydoc = "0.1"
 secrecy = "0.6"
 subtle-encoding = { version = "0.5.1", features = ["bech32-preview"] }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,79 +1,44 @@
 //! Error types
 
-use anomaly::{BoxError, Context};
-use displaydoc::Display;
-use std::{
-    fmt::{self, Display},
-    ops::Deref,
-};
+use std::fmt::{self, Display};
 
 /// Kinds of errors
-#[derive(Copy, Clone, Debug, Display, Eq, PartialEq)]
-pub enum ErrorKind {
-    /// unknown or unsupported algorithm
-    AlgorithmInvalid,
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Error {
+    /// Unknown or unsupported algorithm
+    Algorithm(String),
 
-    /// checksum error
-    ChecksumInvalid,
+    /// Checksum error
+    Checksum,
+
+    /// Length error
+    Length {
+        /// Actual length
+        actual: usize,
+
+        /// Expected length
+        expected: usize,
+    },
 
     /// parse error
-    ParseError,
+    Parse,
 
     /// unknown URI scheme
-    SchemeInvalid,
+    Scheme(String),
 }
 
-impl ErrorKind {
-    /// Add context to an [`ErrorKind`]
-    pub fn context(self, source: impl Into<BoxError>) -> Context<ErrorKind> {
-        Context::new(self, Some(source.into()))
-    }
-}
-
-impl std::error::Error for ErrorKind {}
-
-/// Error type
-#[derive(Debug)]
-pub struct Error(Box<Context<ErrorKind>>);
-
-impl Deref for Error {
-    type Target = Context<ErrorKind>;
-
-    fn deref(&self) -> &Context<ErrorKind> {
-        &self.0
-    }
-}
+impl std::error::Error for Error {}
 
 impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl std::error::Error for Error {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        self.0.source()
-    }
-}
-
-impl From<ErrorKind> for Error {
-    fn from(kind: ErrorKind) -> Self {
-        Context::new(kind, None).into()
-    }
-}
-
-impl From<Context<ErrorKind>> for Error {
-    fn from(context: Context<ErrorKind>) -> Self {
-        Error(Box::new(context))
-    }
-}
-
-impl From<subtle_encoding::Error> for Error {
-    fn from(err: subtle_encoding::Error) -> Error {
-        match err {
-            subtle_encoding::Error::ChecksumInvalid => ErrorKind::ChecksumInvalid,
-            _ => ErrorKind::ParseError,
+        match self {
+            Error::Algorithm(alg) => write!(f, "algorithm invalid: '{}'", alg),
+            Error::Checksum => write!(f, "checksum invalid"),
+            Error::Length { expected, actual } => {
+                write!(f, "length invalid: {} (expected {})", actual, expected)
+            }
+            Error::Parse => write!(f, "parse error"),
+            Error::Scheme(scheme) => write!(f, "scheme invalid: '{}'", scheme),
         }
-        .into()
     }
 }

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -6,11 +6,7 @@ mod sha2;
 pub use self::sha2::Sha256Hash;
 
 use crate::algorithm::SHA256_ALG_ID;
-use crate::{
-    encoding::Encodable,
-    error::{Error, ErrorKind},
-};
-use anomaly::fail;
+use crate::{encoding::Encodable, error::Error};
 use std::convert::TryInto;
 
 /// Digest (i.e. hash) algorithms
@@ -22,12 +18,10 @@ pub enum Hash {
 impl Hash {
     /// Create a new `Digest` for the given algorithm
     pub fn new(alg: &str, bytes: &[u8]) -> Result<Self, Error> {
-        let result = match alg {
-            SHA256_ALG_ID => Hash::Sha256(bytes.try_into()?),
-            _ => fail!(ErrorKind::AlgorithmInvalid, "{}", alg),
-        };
-
-        Ok(result)
+        match alg {
+            SHA256_ALG_ID => Ok(Hash::Sha256(bytes.try_into()?)),
+            _ => Err(Error::Algorithm(alg.to_owned())),
+        }
     }
 
     /// Return a `Sha256Digest` if the underlying digest is SHA-256

--- a/src/hash/sha2.rs
+++ b/src/hash/sha2.rs
@@ -1,10 +1,6 @@
 //! SHA2 hash types
 
-use crate::{
-    algorithm::SHA256_ALG_ID,
-    error::{Error, ErrorKind},
-};
-use anomaly::format_err;
+use crate::{algorithm::SHA256_ALG_ID, error::Error};
 use std::convert::{TryFrom, TryInto};
 
 /// Size of a SHA-256 hash
@@ -17,14 +13,9 @@ impl TryFrom<&[u8]> for Sha256Hash {
     type Error = Error;
 
     fn try_from(slice: &[u8]) -> Result<Self, Error> {
-        slice.try_into().map(Sha256Hash).map_err(|_| {
-            format_err!(
-                ErrorKind::ParseError,
-                "bad SHA-256 hash length: {} (expected {})",
-                slice.len(),
-                SHA256_HASH_SIZE
-            )
-            .into()
+        slice.try_into().map(Sha256Hash).map_err(|_| Error::Length {
+            actual: slice.len(),
+            expected: SHA256_HASH_SIZE,
         })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,11 +21,7 @@ pub mod secret_key;
 pub mod signature;
 
 pub use crate::{
-    encoding::Encodable,
-    error::{Error, ErrorKind},
-    hash::Hash,
-    public_key::PublicKey,
-    secret_key::SecretKey,
+    encoding::Encodable, error::Error, hash::Hash, public_key::PublicKey, secret_key::SecretKey,
     signature::Signature,
 };
 
@@ -33,7 +29,6 @@ use crate::{
     encoding::{Encoding, DASHERIZED_ENCODING, URI_ENCODING},
     parts::Parts,
 };
-use anomaly::fail;
 use secrecy::{ExposeSecret, SecretString};
 
 /// `CryptoUri`: URI-based format for encoding cryptographic objects
@@ -95,11 +90,7 @@ impl CryptoUri {
                 parts.data.expose_secret(),
             )?)
         } else {
-            fail!(
-                ErrorKind::SchemeInvalid,
-                "unknown CryptoURI prefix: {}",
-                parts.prefix
-            )
+            return Err(Error::Scheme(parts.prefix.to_owned()));
         };
 
         Ok(Self {

--- a/src/parts.rs
+++ b/src/parts.rs
@@ -24,8 +24,9 @@ impl Parts {
         if let Some(delimiter) = encoding.fragment_delimiter {
             if let Some(pos) = uri.find(delimiter) {
                 let fragment = uri[(pos + 1)..].to_owned();
-                let (prefix, data) =
-                    Bech32::new(bech32::DEFAULT_CHARSET, encoding.delimiter).decode(&uri[..pos])?;
+                let (prefix, data) = Bech32::new(bech32::DEFAULT_CHARSET, encoding.delimiter)
+                    .decode(&uri[..pos])
+                    .map_err(|_| Error::Parse)?;
 
                 return Ok(Self {
                     prefix,
@@ -35,8 +36,9 @@ impl Parts {
             }
         }
 
-        let (prefix, data) =
-            Bech32::new(bech32::DEFAULT_CHARSET, encoding.delimiter).decode(uri)?;
+        let (prefix, data) = Bech32::new(bech32::DEFAULT_CHARSET, encoding.delimiter)
+            .decode(uri)
+            .map_err(|_| Error::Parse)?;
 
         Ok(Self {
             prefix,

--- a/src/public_key.rs
+++ b/src/public_key.rs
@@ -1,11 +1,6 @@
 //! Public key types
 
-use crate::{
-    algorithm::ED25519_ALG_ID,
-    encoding::Encodable,
-    error::{Error, ErrorKind},
-};
-use anomaly::fail;
+use crate::{algorithm::ED25519_ALG_ID, encoding::Encodable, error::Error};
 use std::convert::TryInto;
 
 /// Ed25519 elliptic curve digital signature algorithm (RFC 8032)
@@ -22,12 +17,10 @@ pub enum PublicKey {
 impl PublicKey {
     /// Create a new `PublicKey` for the given algorithm
     pub fn new(alg: &str, bytes: &[u8]) -> Result<Self, Error> {
-        let result = match alg {
-            ED25519_ALG_ID => PublicKey::Ed25519(bytes.try_into()?),
-            _ => fail!(ErrorKind::AlgorithmInvalid, "{}", alg),
-        };
-
-        Ok(result)
+        match alg {
+            ED25519_ALG_ID => Ok(PublicKey::Ed25519(bytes.try_into()?)),
+            _ => Err(Error::Algorithm(alg.to_owned())),
+        }
     }
 
     /// Return an `Ed25519PublicKey` if the underlying public key is Ed25519

--- a/src/public_key/ed25519.rs
+++ b/src/public_key/ed25519.rs
@@ -1,10 +1,6 @@
 //! Ed25519 public keys
 
-use crate::{
-    algorithm::ED25519_ALG_ID,
-    error::{Error, ErrorKind},
-};
-use anomaly::format_err;
+use crate::{algorithm::ED25519_ALG_ID, error::Error};
 use std::convert::{TryFrom, TryInto};
 
 /// Size of an Ed25519 public key
@@ -17,15 +13,13 @@ impl TryFrom<&[u8]> for Ed25519PublicKey {
     type Error = Error;
 
     fn try_from(slice: &[u8]) -> Result<Self, Error> {
-        slice.try_into().map(Ed25519PublicKey).map_err(|_| {
-            format_err!(
-                ErrorKind::ParseError,
-                "bad Ed25519 public key length: {} (expected {})",
-                slice.len(),
-                ED25519_PUBKEY_SIZE
-            )
-            .into()
-        })
+        slice
+            .try_into()
+            .map(Ed25519PublicKey)
+            .map_err(|_| Error::Length {
+                actual: slice.len(),
+                expected: ED25519_PUBKEY_SIZE,
+            })
     }
 }
 

--- a/src/secret_key/aesgcm.rs
+++ b/src/secret_key/aesgcm.rs
@@ -2,9 +2,8 @@
 
 use crate::{
     algorithm::{AES128GCM_ALG_ID, AES256GCM_ALG_ID},
-    error::{Error, ErrorKind},
+    error::Error,
 };
-use anomaly::format_err;
 use secrecy::{DebugSecret, ExposeSecret, Secret};
 use std::convert::{TryFrom, TryInto};
 
@@ -31,13 +30,9 @@ macro_rules! impl_aes_gcm_key {
                 slice
                     .try_into()
                     .map(|bytes| $name(Secret::new(bytes)))
-                    .map_err(|_| {
-                        format_err!(
-                            ErrorKind::ParseError,
-                            concat!("bad ", $desc, "key: expected ", $key_size, "-bytes, got {}"),
-                            slice.len(),
-                        )
-                        .into()
+                    .map_err(|_| Error::Length {
+                        actual: slice.len(),
+                        expected: $key_size,
                     })
             }
         }

--- a/src/secret_key/chacha20poly1305.rs
+++ b/src/secret_key/chacha20poly1305.rs
@@ -1,10 +1,6 @@
 //! ChaCha20Poly1305 AEAD (RFC 8439)
 
-use crate::{
-    algorithm::CHACHA20POLY1305_ALG_ID,
-    error::{Error, ErrorKind},
-};
-use anomaly::format_err;
+use crate::{algorithm::CHACHA20POLY1305_ALG_ID, error::Error};
 use secrecy::{DebugSecret, ExposeSecret, Secret};
 use std::convert::{TryFrom, TryInto};
 
@@ -22,13 +18,9 @@ impl TryFrom<&[u8]> for ChaCha20Poly1305Key {
         slice
             .try_into()
             .map(|bytes| ChaCha20Poly1305Key(Secret::new(bytes)))
-            .map_err(|_| {
-                format_err!(
-                    ErrorKind::ParseError,
-                    "bad ChaCha20Poly1305 key: expected 32-bytes, got {}",
-                    slice.len(),
-                )
-                .into()
+            .map_err(|_| Error::Length {
+                actual: slice.len(),
+                expected: 32,
             })
     }
 }

--- a/src/secret_key/ed25519.rs
+++ b/src/secret_key/ed25519.rs
@@ -1,10 +1,6 @@
 //! The Ed25519 digital signature algorithm
 
-use crate::{
-    algorithm::ED25519_ALG_ID,
-    error::{Error, ErrorKind},
-};
-use anomaly::format_err;
+use crate::{algorithm::ED25519_ALG_ID, error::Error};
 use secrecy::{DebugSecret, ExposeSecret, Secret};
 use std::convert::{TryFrom, TryInto};
 
@@ -22,13 +18,9 @@ impl TryFrom<&[u8]> for Ed25519SecretKey {
         slice
             .try_into()
             .map(|bytes| Ed25519SecretKey(Secret::new(bytes)))
-            .map_err(|_| {
-                format_err!(
-                    ErrorKind::ParseError,
-                    "bad Ed25519 secret key length: {} (expected 32-bytes)",
-                    slice.len(),
-                )
-                .into()
+            .map_err(|_| Error::Length {
+                actual: slice.len(),
+                expected: 32,
             })
     }
 }

--- a/src/secret_key/hkdf.rs
+++ b/src/secret_key/hkdf.rs
@@ -4,9 +4,8 @@ use super::Algorithm;
 use crate::{
     algorithm::HKDFSHA256_ALG_ID,
     encoding::{Encodable, DASHERIZED_ENCODING, URI_ENCODING},
-    error::{Error, ErrorKind},
+    error::Error,
 };
-use anomaly::{fail, format_err};
 use secrecy::{DebugSecret, ExposeSecret, Secret};
 use std::convert::{TryFrom, TryInto};
 
@@ -27,11 +26,7 @@ impl HkdfSha256Key {
     /// Create a new HKDF-SHA-256 key
     pub fn new(bytes: &[u8], derived_alg: Algorithm) -> Result<Self, Error> {
         if derived_alg == Algorithm::HkdfSha256 {
-            fail!(
-                ErrorKind::ParseError,
-                "invalid algorithm at end of combination: {}",
-                derived_alg
-            );
+            return Err(Error::Algorithm(derived_alg.to_string()));
         }
 
         let mut key = Self::try_from(bytes)?;
@@ -55,13 +50,9 @@ impl TryFrom<&[u8]> for HkdfSha256Key {
                 ikm: Secret::new(bytes),
                 derived_alg: None,
             })
-            .map_err(|_| {
-                format_err!(
-                    ErrorKind::ParseError,
-                    "bad HKDF-SHA-256 secret key length: {} (expected 32-bytes)",
-                    slice.len(),
-                )
-                .into()
+            .map_err(|_| Error::Length {
+                actual: slice.len(),
+                expected: 32,
             })
     }
 }

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -5,12 +5,7 @@ mod ed25519;
 
 pub use self::ed25519::Ed25519Signature;
 
-use crate::{
-    algorithm::ED25519_ALG_ID,
-    encoding::Encodable,
-    error::{Error, ErrorKind},
-};
-use anomaly::fail;
+use crate::{algorithm::ED25519_ALG_ID, encoding::Encodable, error::Error};
 use std::convert::TryInto;
 
 /// Signature algorithms
@@ -22,12 +17,10 @@ pub enum Signature {
 impl Signature {
     /// Create a new `Signature` for the given algorithm
     pub fn new(alg: &str, bytes: &[u8]) -> Result<Self, Error> {
-        let result = match alg {
-            ED25519_ALG_ID => Signature::Ed25519(bytes.try_into()?),
-            _ => fail!(ErrorKind::AlgorithmInvalid, "{}", alg),
-        };
-
-        Ok(result)
+        match alg {
+            ED25519_ALG_ID => Ok(Signature::Ed25519(bytes.try_into()?)),
+            _ => Err(Error::Algorithm(alg.to_owned())),
+        }
     }
 
     /// Return an `Ed25519Signature` if the underlying signature is Ed25519

--- a/src/signature/ed25519.rs
+++ b/src/signature/ed25519.rs
@@ -1,10 +1,6 @@
 //! Ed25519 signatures
 
-use crate::{
-    algorithm::ED25519_ALG_ID,
-    error::{Error, ErrorKind},
-};
-use anomaly::fail;
+use crate::{algorithm::ED25519_ALG_ID, error::Error};
 use core::convert::TryFrom;
 
 /// Size of an Ed25519 signature
@@ -20,12 +16,10 @@ impl TryFrom<&[u8]> for Ed25519Signature {
         // NOTE: Can't use `TryInto` here because `[u8; 64]` doesn't impl
         // `TryFrom<&[u8]>`
         if slice.len() != ED25519_SIGNATURE_SIZE {
-            fail!(
-                ErrorKind::ParseError,
-                "bad Ed25519 signature length: {} (expected {})",
-                slice.len(),
-                ED25519_SIGNATURE_SIZE
-            );
+            return Err(Error::Length {
+                actual: slice.len(),
+                expected: ED25519_SIGNATURE_SIZE,
+            });
         }
 
         let mut sig_bytes = [0u8; ED25519_SIGNATURE_SIZE];


### PR DESCRIPTION
Removes error handling dependencies in favor of a more barebones approach.

Removes the previous `Error` struct, and renames `ErrorKind` to `Error`, also renaming some of the variants.