### PR TITLE
Replace `secrecy` with `zeroize`; MSRV 1.60

### DIFF
--- a/.github/workflows/cryptouri.yml
+++ b/.github/workflows/cryptouri.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - rust: 1.56.0 # MSRV
+          - rust: 1.60.0 # MSRV
           - rust: stable
 
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,16 +6,7 @@ version = 3
 name = "cryptouri"
 version = "0.5.0-pre"
 dependencies = [
- "secrecy",
  "subtle-encoding",
-]
-
-[[package]]
-name = "secrecy"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9182278ed645df3477a9c27bfee0621c621aa16f6972635f7f795dae3d81070f"
-dependencies = [
  "zeroize",
 ]
 
@@ -30,6 +21,6 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.1.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cbac2ed2ba24cc90f5e06485ac8c7c1e5449fe8911aef4d8877218af021a5b8"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,11 @@ readme = "README.md"
 categories = ["cryptography", "encoding"]
 keywords = ["bech32", "cryptography", "keys", "security", "uri"]
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.60"
 
 [badges]
 travis-ci = { repository = "cryptouri/cryptouri.rs" }
 
 [dependencies]
-secrecy = "0.6"
 subtle-encoding = { version = "0.5.1", features = ["bech32-preview"] }
+zeroize = "1.7"

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ CryptoURIs which have been mis-transcribed will fail to decode.
 
 ## Minimum Supported Rust Version
 
-- Rust **1.56+**
+- Rust **1.60+**
 
 ## Code of Conduct
 
@@ -74,7 +74,7 @@ The **cryptouri** Rust crate is dual licensed under your choice of either of:
 [safety-image]: https://img.shields.io/badge/unsafe-forbidden-success.svg
 [safety-link]: https://github.com/rust-secure-code/safety-dance/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[msrv-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[msrv-image]: https://img.shields.io/badge/rustc-1.60+-blue.svg
 
 [//]: # (links)
 

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -107,7 +107,6 @@ macro_rules! impl_encodable_secret_key {
         impl crate::encoding::Encodable for $name {
             #[inline]
             fn to_uri_string(&self) -> String {
-                use secrecy::ExposeSecret;
                 use subtle_encoding::bech32::{self, Bech32};
                 Bech32::new(
                     bech32::DEFAULT_CHARSET,
@@ -115,13 +114,12 @@ macro_rules! impl_encodable_secret_key {
                 )
                 .encode(
                     $crate::encoding::URI_ENCODING.secret_key_scheme.to_owned() + $alg,
-                    &self.expose_secret()[..],
+                    &self.as_ref()[..],
                 )
             }
 
             #[inline]
             fn to_dasherized_string(&self) -> String {
-                use secrecy::ExposeSecret;
                 use subtle_encoding::bech32::{self, Bech32};
                 Bech32::new(
                     bech32::DEFAULT_CHARSET,
@@ -132,7 +130,7 @@ macro_rules! impl_encodable_secret_key {
                         .secret_key_scheme
                         .to_owned()
                         + $alg,
-                    &self.expose_secret()[..],
+                    &self.as_ref()[..],
                 )
             }
         }

--- a/src/hash/sha2.rs
+++ b/src/hash/sha2.rs
@@ -1,7 +1,6 @@
 //! SHA2 hash types
 
 use crate::{algorithm::SHA256_ALG_ID, error::Error};
-use std::convert::{TryFrom, TryInto};
 
 /// Size of a SHA-256 hash
 pub const SHA256_HASH_SIZE: usize = 32;

--- a/src/parts.rs
+++ b/src/parts.rs
@@ -1,8 +1,8 @@
 //! CryptoURI parts
 
 use crate::{encoding::Encoding, error::Error};
-use secrecy::{Secret, SecretString, SecretVec};
 use subtle_encoding::bech32::{self, Bech32};
+use zeroize::Zeroize;
 
 /// Parts of a CryptoURI
 pub(crate) struct Parts {
@@ -10,10 +10,10 @@ pub(crate) struct Parts {
     pub(crate) prefix: String,
 
     /// Data (i.e. public or private key or key fingerprint)
-    pub(crate) data: SecretVec<u8>,
+    pub(crate) data: Vec<u8>,
 
     /// URI fragment (i.e. comment)
-    pub(crate) fragment: Option<SecretString>,
+    pub(crate) fragment: Option<String>,
 }
 
 impl Parts {
@@ -30,8 +30,8 @@ impl Parts {
 
                 return Ok(Self {
                     prefix,
-                    data: Secret::new(data),
-                    fragment: Some(Secret::new(fragment)),
+                    data,
+                    fragment: Some(fragment),
                 });
             }
         }
@@ -42,8 +42,15 @@ impl Parts {
 
         Ok(Self {
             prefix,
-            data: Secret::new(data),
+            data,
             fragment: None,
         })
+    }
+}
+
+impl Drop for Parts {
+    fn drop(&mut self) {
+        self.data.zeroize();
+        self.fragment.zeroize();
     }
 }

--- a/src/secret_key.rs
+++ b/src/secret_key.rs
@@ -11,7 +11,6 @@ pub use self::{
     ed25519::Ed25519SecretKey,
     hkdf::HkdfSha256Key,
 };
-pub use secrecy::ExposeSecret;
 
 use crate::{
     algorithm::{
@@ -22,7 +21,6 @@ use crate::{
     error::Error,
 };
 use std::{
-    convert::TryInto,
     fmt::{self, Display},
     str::FromStr,
 };

--- a/src/secret_key/aesgcm.rs
+++ b/src/secret_key/aesgcm.rs
@@ -4,8 +4,7 @@ use crate::{
     algorithm::{AES128GCM_ALG_ID, AES256GCM_ALG_ID},
     error::Error,
 };
-use secrecy::{DebugSecret, ExposeSecret, Secret};
-use std::convert::{TryFrom, TryInto};
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 /// Size of an AES-128 key in bytes
 pub const AES128_KEY_SIZE: usize = 16;
@@ -15,21 +14,33 @@ pub const AES256_KEY_SIZE: usize = 32;
 
 /// AES-128 in Galois/Counter Mode (GCM)
 #[derive(Clone)]
-pub struct Aes128GcmKey(Secret<[u8; AES128_KEY_SIZE]>);
+pub struct Aes128GcmKey(Box<[u8; AES128_KEY_SIZE]>);
 
 /// AES-256 in Galois/Counter Mode (GCM)
 #[derive(Clone)]
-pub struct Aes256GcmKey(Secret<[u8; AES256_KEY_SIZE]>);
+pub struct Aes256GcmKey(Box<[u8; AES256_KEY_SIZE]>);
 
 macro_rules! impl_aes_gcm_key {
     ($name:ident, $key_size:expr, $desc:expr) => {
+        impl AsRef<[u8; $key_size]> for $name {
+            fn as_ref(&self) -> &[u8; $key_size] {
+                &self.0
+            }
+        }
+
+        impl Drop for $name {
+            fn drop(&mut self) {
+                self.0.zeroize();
+            }
+        }
+
         impl TryFrom<&[u8]> for $name {
             type Error = Error;
 
             fn try_from(slice: &[u8]) -> Result<Self, Error> {
                 slice
                     .try_into()
-                    .map(|bytes| $name(Secret::new(bytes)))
+                    .map(|bytes| $name(Box::new(bytes)))
                     .map_err(|_| Error::Length {
                         actual: slice.len(),
                         expected: $key_size,
@@ -37,13 +48,7 @@ macro_rules! impl_aes_gcm_key {
             }
         }
 
-        impl DebugSecret for $name {}
-
-        impl ExposeSecret<[u8; $key_size]> for $name {
-            fn expose_secret(&self) -> &[u8; $key_size] {
-                self.0.expose_secret()
-            }
-        }
+        impl ZeroizeOnDrop for $name {}
     };
 }
 

--- a/src/secret_key/chacha20poly1305.rs
+++ b/src/secret_key/chacha20poly1305.rs
@@ -1,15 +1,26 @@
 //! ChaCha20Poly1305 AEAD (RFC 8439)
 
 use crate::{algorithm::CHACHA20POLY1305_ALG_ID, error::Error};
-use secrecy::{DebugSecret, ExposeSecret, Secret};
-use std::convert::{TryFrom, TryInto};
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 /// Size of a ChaCha20Poly1305 key in bytes
 pub const CHACHA20POLY1305_KEY_SIZE: usize = 32;
 
 /// ChaCha20Poly1305 encryption key
 #[derive(Clone)]
-pub struct ChaCha20Poly1305Key(Secret<[u8; CHACHA20POLY1305_KEY_SIZE]>);
+pub struct ChaCha20Poly1305Key(Box<[u8; CHACHA20POLY1305_KEY_SIZE]>);
+
+impl AsRef<[u8; CHACHA20POLY1305_KEY_SIZE]> for ChaCha20Poly1305Key {
+    fn as_ref(&self) -> &[u8; CHACHA20POLY1305_KEY_SIZE] {
+        &self.0
+    }
+}
+
+impl Drop for ChaCha20Poly1305Key {
+    fn drop(&mut self) {
+        self.0.zeroize();
+    }
+}
 
 impl TryFrom<&[u8]> for ChaCha20Poly1305Key {
     type Error = Error;
@@ -17,7 +28,7 @@ impl TryFrom<&[u8]> for ChaCha20Poly1305Key {
     fn try_from(slice: &[u8]) -> Result<Self, Error> {
         slice
             .try_into()
-            .map(|bytes| ChaCha20Poly1305Key(Secret::new(bytes)))
+            .map(|bytes| ChaCha20Poly1305Key(Box::new(bytes)))
             .map_err(|_| Error::Length {
                 actual: slice.len(),
                 expected: 32,
@@ -25,12 +36,6 @@ impl TryFrom<&[u8]> for ChaCha20Poly1305Key {
     }
 }
 
-impl DebugSecret for ChaCha20Poly1305Key {}
-
-impl ExposeSecret<[u8; CHACHA20POLY1305_KEY_SIZE]> for ChaCha20Poly1305Key {
-    fn expose_secret(&self) -> &[u8; CHACHA20POLY1305_KEY_SIZE] {
-        self.0.expose_secret()
-    }
-}
+impl ZeroizeOnDrop for ChaCha20Poly1305Key {}
 
 impl_encodable_secret_key!(ChaCha20Poly1305Key, CHACHA20POLY1305_ALG_ID);

--- a/src/signature/ed25519.rs
+++ b/src/signature/ed25519.rs
@@ -1,7 +1,6 @@
 //! Ed25519 signatures
 
 use crate::{algorithm::ED25519_ALG_ID, error::Error};
-use core::convert::TryFrom;
 
 /// Size of an Ed25519 signature
 pub const ED25519_SIGNATURE_SIZE: usize = 64;

--- a/tests/secret_key_test.rs
+++ b/tests/secret_key_test.rs
@@ -3,25 +3,18 @@ macro_rules! secret_key_test {
         mod $name {
             use cryptouri::secret_key::$keytype;
             use cryptouri::{CryptoUri, Encodable};
-            use secrecy::ExposeSecret;
             use std::convert::TryFrom;
 
             #[test]
             fn parse_uri() {
                 let key = CryptoUri::parse_uri($uri).unwrap();
-                assert_eq!(
-                    key.secret_key().unwrap().$name().unwrap().expose_secret(),
-                    $bytes
-                );
+                assert_eq!(key.secret_key().unwrap().$name().unwrap().as_ref(), $bytes);
             }
 
             #[test]
             fn parse_dasherized() {
                 let key = CryptoUri::parse_dasherized($dasherized).unwrap();
-                assert_eq!(
-                    key.secret_key().unwrap().$name().unwrap().expose_secret(),
-                    $bytes
-                );
+                assert_eq!(key.secret_key().unwrap().$name().unwrap().as_ref(), $bytes);
             }
 
             #[test]


### PR DESCRIPTION
The `secrecy` version is out-of-date and represents another dependency which can be eliminated by using a zeroize-on-drop approach.